### PR TITLE
Better VS Code settings and Remove Ruff Extension

### DIFF
--- a/templates/base/.devcontainer.json
+++ b/templates/base/.devcontainer.json
@@ -14,6 +14,10 @@
 
     "customizations": {
         "vscode": {
+            "settings": {
+                "editor.defaultFormatter": "esbenp.prettier-vscode",
+                "editor.rulers": [100]
+            },
             "extensions": [
                 "eamodio.gitlens",
                 "esbenp.prettier-vscode",

--- a/templates/python/.devcontainer.json
+++ b/templates/python/.devcontainer.json
@@ -22,14 +22,14 @@
                 "tamasfe.even-better-toml"
             ],
             "settings": {
-                "autoDocstring.customTemplatePath": "/usr/local/share/style/docstring-template.mustache",
                 "[python]": {
-                    "editor.rulers": [100],
-                    "python.analysis.typeCheckingMode": "strict",
-                    "python.testing.pytestArgs": ["tests"],
-                    "python.testing.pytestEnabled": true,
-                    "python.testing.unittestEnabled": false
-                }
+                    "editor.defaultFormatter": "ms-python.black-formatter"
+                },
+                "autoDocstring.customTemplatePath": "/usr/local/share/style/docstring-template.mustache",
+                "python.analysis.typeCheckingMode": "strict",
+                "python.testing.pytestArgs": ["tests"],
+                "python.testing.pytestEnabled": true,
+                "python.testing.unittestEnabled": false
             }
         }
     },

--- a/templates/python/.devcontainer.json
+++ b/templates/python/.devcontainer.json
@@ -12,7 +12,6 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "charliermarsh.ruff",
                 "ms-python.black-formatter",
                 "ms-python.isort",
                 "ms-python.pylint",


### PR DESCRIPTION
- Configure Prettier as the default formatter for everything.
- Override Black as the default formatter for Python.
- Extract 100 character ruler from Python to everything.
  We format most things with a 100-character line length but can override this where necessary.
- Move typing and testing settings from the `[python]` object to the top level to ensure they are accessible.
- Remove Ruff extension (details below)

### Ruff

> TL;DR: Migrating to Ruff takes a lot more than installing a VS Code extension.

Black and Ruff conflict with each other (as mentioned [here](https://situworkspace.slack.com/archives/C03N9MRM0P2/p1712278131711269)).

While Ruff is a drop-in replacement for Black, the following changes must also occur:
- we must discuss whether to lint with Ruff or Pylint;
- we must discuss whether to handle imports with Ruff or Isort;
- GitHub status checks must change to use Ruff instead of Black (and potentially have Pylint and/or Isort removed); and
- every Python repo must remove Black (and potentially Pylint and/or Isort) and add Ruff (and potentially its configuration).