### PR TITLE
Revert "Use `status-check-runner`'s Extended JSON Schema for `pyproject.toml`"

### DIFF
--- a/templates/python/.devcontainer.json
+++ b/templates/python/.devcontainer.json
@@ -23,9 +23,6 @@
                     "editor.defaultFormatter": "charliermarsh.ruff"
                 },
                 "autoDocstring.customTemplatePath": "/usr/local/share/style/docstring-template.mustache",
-                "evenBetterToml.schema.associations": {
-                    "pyproject.toml": "https://raw.githubusercontent.com/willsawyerrrr/status-check-runner/main/pyproject.json"
-                },
                 "python.testing.pytestArgs": ["tests"],
                 "python.testing.pytestEnabled": true,
                 "python.testing.unittestEnabled": false

--- a/templates/python/devcontainer-template.json
+++ b/templates/python/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "python",
-    "version": "1.4.0",
+    "version": "1.3.0",
     "name": "Python Dev Container",
     "description": "Python Dev Container template"
 }


### PR DESCRIPTION
Reverts SituDevelopment/devcontainers#70

`status-check-runner` cannot use `pyproject.toml` for configuration since it must be usable in non-Python projects.